### PR TITLE
Add a trajectory buffer to store trajectories to be added to replay memory.

### DIFF
--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -381,14 +381,14 @@ class OutOfGraphReplayBuffer(object):
   def get_range(self, array, start_index, end_index):
     """Returns the range of array at the index handling wraparound if necessary.
 
-     Args:
+    Args:
       array: np.array, the array to get the stack from.
       start_index: int, index to the start of the range to be returned. Range
         will wraparound if start_index is smaller than 0.
       end_index: int, exclusive end index. Range will wraparound if end_index
         exceeds replay_capacity.
 
-     Returns:
+    Returns:
       np.array, with shape [end_index - start_index, array.shape[1:]].
     """
     assert end_index > start_index, 'end_index must be larger than start_index'

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -259,7 +259,7 @@ class OutOfGraphReplayBuffer(object):
     for element_type in self.get_add_args_signature():
       zero_transition.append(
           np.zeros(element_type.shape, dtype=element_type.type))
-    self._add(*zero_transition)
+    self._add_transition_to_memory(*zero_transition)
 
   @lock_lib.locked_method()
   def add(self, observation, action, reward, terminal, *args):
@@ -283,10 +283,9 @@ class OutOfGraphReplayBuffer(object):
         extra_storage_types.
     """
     self._check_add_types(observation, action, reward, terminal, *args)
-    self._add_to_trajectory_buffer(observation, action, reward, terminal, *args)
+    self._add(observation, action, reward, terminal, *args)
 
-  def _add_to_trajectory_buffer(
-      self, observation, action, reward, terminal, *args):
+  def _add(self, observation, action, reward, terminal, *args):
     """Adds a transition to the trajectory buffer.
 
     Transitions are added to a trajectory until a terminal step is encountered
@@ -332,9 +331,9 @@ class OutOfGraphReplayBuffer(object):
     trajectory = self._trajectories.pop(trajectory_index)
     self._trajectory_lengths.pop(trajectory_index)
     for step_args in trajectory:
-      self._add(*step_args)
+      self._add_transition_to_memory(*step_args)
 
-  def _add(self, *args):
+  def _add_transition_to_memory(self, *args):
     """Internal add method to add to the storage arrays.
 
     Args:

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -283,12 +283,10 @@ class OutOfGraphReplayBuffer(object):
         extra_storage_types.
     """
     self._check_add_types(observation, action, reward, terminal, *args)
-    trajectory_index = self._get_current_trajectory()
-    self._add_to_trajectory_buffer(
-        trajectory_index, observation, action, reward, terminal, *args)
+    self._add_to_trajectory_buffer(observation, action, reward, terminal, *args)
 
   def _add_to_trajectory_buffer(
-      self, trajectory_index, observation, action, reward, terminal, *args):
+      self, observation, action, reward, terminal, *args):
     """Adds a transition to the trajectory buffer.
 
     Transitions are added to a trajectory until a terminal step is encountered
@@ -296,7 +294,6 @@ class OutOfGraphReplayBuffer(object):
     trajectory stored to the buffer is added to the memory and emptied.
 
     Args:
-      trajectory_index: int, index of the trajectory to add to.
       observation: np.array with shape observation_shape.
       action: int, the action in the transition.
       reward: float, the reward received in the transition.
@@ -308,6 +305,7 @@ class OutOfGraphReplayBuffer(object):
       ValueError: If `transition_index` is not in the range
         [0, len(self._trajectories)].
     """
+    trajectory_index = self._get_current_trajectory()
     if not 0 <= trajectory_index < len(self._trajectories):
       raise ValueError(
           '`trajectory_index` must be in the '
@@ -321,14 +319,11 @@ class OutOfGraphReplayBuffer(object):
 
     if terminal or (self._max_trajectory_size and (
         len(trajectory) >= self._max_trajectory_size)):
-      self._add_trajectory_to_memory(trajectory_index)
+      self._add_trajectory_to_memory()
 
-  def _add_trajectory_to_memory(self, trajectory_index):
-    """Add a stored trajectory buffer to the replay memory.
-
-    Args:
-      trajectory_index: int, the index of the trajectory to add to the memory.
-    """
+  def _add_trajectory_to_memory(self):
+    """Add a stored trajectory buffer to the replay memory."""
+    trajectory_index = self._get_current_trajectory()
     if self.is_empty() or self._store['terminal'][self.cursor() - 1] == 1:
       for _ in range(self._stack_size - 1):
         # Child classes can rely on the padding transitions being filled with

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -205,8 +205,8 @@ class OutOfGraphReplayBuffer(object):
     self._trajectories = []
     self._trajectory_lengths = []
 
-  def _get_last_trajectory(self):
-    """Returns last trajectory to write to and creates a new one if needed.
+  def _get_current_trajectory(self):
+    """Returns ongoing trajectory to write to and creates a new one if needed.
 
     Returns:
       int, the index of the last trajectory to write to.
@@ -219,7 +219,7 @@ class OutOfGraphReplayBuffer(object):
     new_transition = []
     self._trajectories.append(new_transition)
     self._trajectory_lengths.append(0)
-    return self._get_last_trajectory()
+    return self._get_current_trajectory()
 
   def get_add_args_signature(self):
     """The signature of the add function.
@@ -283,12 +283,12 @@ class OutOfGraphReplayBuffer(object):
         extra_storage_types.
     """
     self._check_add_types(observation, action, reward, terminal, *args)
-    trajectory_index = self._get_last_trajectory()
-    self._add_to_trajectory(
+    trajectory_index = self._get_current_trajectory()
+    self._add_to_trajectory_buffer(
         trajectory_index, observation, action, reward, terminal, *args)
 
-  def _add_to_trajectory(self, trajectory_index, observation, action, reward,
-                         terminal, *args):
+  def _add_to_trajectory_buffer(
+      self, trajectory_index, observation, action, reward, terminal, *args):
     """Adds a transition to the trajectory buffer.
 
     Transitions are added to a trajectory until a terminal step is encountered
@@ -321,7 +321,7 @@ class OutOfGraphReplayBuffer(object):
 
     if terminal or (self._max_trajectory_buffer and (
         len(trajectory) >= self._max_trajectory_buffer)):
-      self._add_trajectory_to_buffer(trajectory_index)
+      self._add_trajectory_to_memory(trajectory_index)
 
   def _add_trajectory_to_memory(self, trajectory_index):
     """Add a stored trajectory buffer to the replay memory.

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -380,12 +380,14 @@ class OutOfGraphReplayBuffer(object):
 
   def get_range(self, array, start_index, end_index):
     """Returns the range of array at the index handling wraparound if necessary.
+
      Args:
       array: np.array, the array to get the stack from.
       start_index: int, index to the start of the range to be returned. Range
         will wraparound if start_index is smaller than 0.
       end_index: int, exclusive end index. Range will wraparound if end_index
         exceeds replay_capacity.
+
      Returns:
       np.array, with shape [end_index - start_index, array.shape[1:]].
     """
@@ -396,7 +398,7 @@ class OutOfGraphReplayBuffer(object):
       assert end_index <= self.cursor(), (
           'Index {} has not been added.'.format(start_index))
 
-     # Fast slice read when there is no wraparound.
+    # Fast slice read when there is no wraparound.
     if start_index % self._replay_capacity < end_index % self._replay_capacity:
       return_array = array[start_index:end_index, ...]
     # Slow list read.

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -315,9 +315,9 @@ class OutOfGraphReplayBuffer(object):
     self._trajectory_lengths[trajectory_index] += 1
 
     if terminal or not self._use_contiguous_trajectories:
-      self._add_trajectory_to_memory()
+      self._add_current_trajectory_to_memory()
 
-  def _add_trajectory_to_memory(self):
+  def _add_current_trajectory_to_memory(self):
     """Add a stored trajectory buffer to the replay memory."""
     trajectory_index = self._get_current_trajectory()
     if self.is_empty() or self._store['terminal'][self.cursor() - 1] == 1:

--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -31,10 +31,10 @@ import os
 import pickle
 
 from dopamine.utils import lock as lock_lib
+import gin.tf
 import numpy as np
 import tensorflow as tf
 
-import gin.tf
 
 # Defines a type describing part of the tuple returned by the replay
 # memory. Each element of the tuple is a tensor of shape [batch, ...] where
@@ -213,7 +213,6 @@ class OutOfGraphReplayBuffer(object):
     """
     if self._trajectories:
       index = len(self._trajectories) - 1
-      transition = self._trajectories[index]
       return index
 
     new_transition = []
@@ -308,7 +307,7 @@ class OutOfGraphReplayBuffer(object):
       ValueError: If `transition_index` is not in the range
         [0, len(self._trajectories)].
     """
-    if not (0 <= trajectory_index < len(self._trajectories)):
+    if not 0 <= trajectory_index < len(self._trajectories):
       raise ValueError(
           '`trajectory_index` must be in the '
           'range [0, {}[. Given {} instead.'.format(
@@ -341,6 +340,7 @@ class OutOfGraphReplayBuffer(object):
 
   def _add(self, *args):
     """Internal add method to add to the storage arrays.
+
     Args:
       *args: All the elements in a transition.
     """

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -712,6 +712,24 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     self.assertEqual(len(memory._trajectories), 0)
     self.assertEqual(len(memory._trajectory_lengths), 0)
 
+  def testTrajectoryBufferSize(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=STACK_SIZE,
+        replay_capacity=20,
+        batch_size=BATCH_SIZE,
+        max_trajectory_buffer=11)
+    self.assertEqual(memory.cursor(), 0)
+    self.assertEqual(len(memory._trajectories), 0)
+    zeros = np.zeros(OBSERVATION_SHAPE)
+    for _ in range(11):
+      memory.add(zeros, 0, 0, 0)
+    expected_length = STACK_SIZE + 10
+    self.assertEqual(memory.cursor(), expected_length)
+    self.assertEqual(memory.add_count, expected_length)
+    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory_lengths), 0)
+
 
 class WrappedReplayBufferTest(tf.test.TestCase):
 

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -680,21 +680,32 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     memory = _create_dummy_memory(lock='lock-name')
     self.assertEqual(memory._lock, 'lock-name')
 
-  def testAddNodeToTrajectoryBuffer(self):
+  def testNodeNotAddedToMemory(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
         observation_shape=OBSERVATION_SHAPE,
-        stack_size=STACK_SIZE,
+        stack_size=1,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
         use_contiguous_trajectories=True)
     self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     memory.add(zeros, 0, 0, 0)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(memory.add_count, 0)
-    self.assertEqual(len(memory._trajectories), 1)
-    self.assertEqual(memory._trajectory_lengths[0], 1)
+
+  def testNodeAddedToTrajectory(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=1,
+        replay_capacity=5,
+        batch_size=BATCH_SIZE,
+        use_contiguous_trajectories=True)
+    self.assertEqual(memory.cursor(), 0)
+    zeros = np.zeros(OBSERVATION_SHAPE)
+    memory.add(zeros, 0, 0, 0)
+    memory.add(zeros, 0, 0, 1)
+    self.assertEqual(memory.cursor(), 2)
+    self.assertEqual(memory.add_count, 2)
 
   def testAddTerminalNodeToTrajectoryBuffer(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -686,7 +686,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        max_trajectory_size=None)
+        contiguous_trajectories=True)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
@@ -702,31 +702,13 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        max_trajectory_size=None)
+        contiguous_trajectories=True)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     memory.add(zeros, 0, 0, 1)
     self.assertEqual(memory.cursor(), STACK_SIZE)
     self.assertEqual(memory.add_count, STACK_SIZE)
-    self.assertEqual(len(memory._trajectories), 0)
-    self.assertEqual(len(memory._trajectory_lengths), 0)
-
-  def testTrajectoryBufferSize(self):
-    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
-        observation_shape=OBSERVATION_SHAPE,
-        stack_size=STACK_SIZE,
-        replay_capacity=20,
-        batch_size=BATCH_SIZE,
-        max_trajectory_size=11)
-    self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
-    zeros = np.zeros(OBSERVATION_SHAPE)
-    for _ in range(11):
-      memory.add(zeros, 0, 0, 0)
-    expected_length = STACK_SIZE + 10
-    self.assertEqual(memory.cursor(), expected_length)
-    self.assertEqual(memory.add_count, expected_length)
     self.assertEqual(len(memory._trajectories), 0)
     self.assertEqual(len(memory._trajectory_lengths), 0)
 

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -686,7 +686,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        contiguous_trajectories=True)
+        use_contiguous_trajectories=True)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
@@ -702,7 +702,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        contiguous_trajectories=True)
+        use_contiguous_trajectories=True)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -680,6 +680,38 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     memory = _create_dummy_memory(lock='lock-name')
     self.assertEqual(memory._lock, 'lock-name')
 
+  def testAddNodeToTrajectoryBuffer(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=STACK_SIZE,
+        replay_capacity=5,
+        batch_size=BATCH_SIZE,
+        max_trajectory_buffer=None)
+    self.assertEqual(memory.cursor(), 0)
+    self.assertEqual(len(memory._trajectories), 0)
+    zeros = np.zeros(OBSERVATION_SHAPE)
+    memory.add(zeros, 0, 0, 0)
+    self.assertEqual(memory.cursor(), 0)
+    self.assertEqual(memory.add_count, 0)
+    self.assertEqual(len(memory._trajectories), 1)
+    self.assertEqual(memory._trajectory_lengths[0], 1)
+
+  def testAddTerminalNodeToTrajectoryBuffer(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=STACK_SIZE,
+        replay_capacity=5,
+        batch_size=BATCH_SIZE,
+        max_trajectory_buffer=None)
+    self.assertEqual(memory.cursor(), 0)
+    self.assertEqual(len(memory._trajectories), 0)
+    zeros = np.zeros(OBSERVATION_SHAPE)
+    memory.add(zeros, 0, 0, 1)
+    self.assertEqual(memory.cursor(), STACK_SIZE)
+    self.assertEqual(memory.add_count, STACK_SIZE)
+    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory_lengths), 0)
+
 
 class WrappedReplayBufferTest(tf.test.TestCase):
 

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -20,10 +20,10 @@ from __future__ import print_function
 import gzip
 import os
 import shutil
-import mock
 
 from absl import flags
 from dopamine.replay_memory import circular_replay_buffer
+import mock
 import numpy as np
 import tensorflow as tf
 

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -686,7 +686,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        max_trajectory_buffer=None)
+        max_trajectory_size=None)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
@@ -702,7 +702,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=5,
         batch_size=BATCH_SIZE,
-        max_trajectory_buffer=None)
+        max_trajectory_size=None)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
@@ -718,7 +718,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         stack_size=STACK_SIZE,
         replay_capacity=20,
         batch_size=BATCH_SIZE,
-        max_trajectory_buffer=11)
+        max_trajectory_size=11)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(len(memory._trajectories), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)


### PR DESCRIPTION
This allows to store entire trajectories at once, consecutively, to the circular replay memory.
This will be useful when several threads write consecutively to the memory to avoid overlap in the transitions of different trajectories.

A follow-up pull request allows to handle multiple trajectory buffers.