### PR TITLE
Allow multiple trajectory buffers

### DIFF
--- a/dopamine/replay_memory/circular_replay_buffer.py
+++ b/dopamine/replay_memory/circular_replay_buffer.py
@@ -301,10 +301,6 @@ class OutOfGraphReplayBuffer(object):
       terminal: A uint8 acting as a boolean indicating whether the transition
                 was terminal (1) or not (0).
       *args: All the elements in a transition.
-
-    Raises:
-      ValueError: If `transition_index` is not in the range
-        [0, len(self._trajectories)].
     """
     trajectory = self._trajectories[trajectory_index]
     trajectory.append(

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -723,7 +723,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     self.assertEqual(memory.add_count, STACK_SIZE)
     self.assertEqual(len(memory._trajectory), 0)
 
-  def testAddMultipleThreads(self):
+  def testAddMultipleThreadsNodeNotAdded(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
         observation_shape=OBSERVATION_SHAPE,
         stack_size=1,
@@ -740,10 +740,26 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
       memory.add(zeros, 0, 0, 1)
     # Check that terminal transition is added by itself.
     self.assertEqual(memory.add_count, 1)
+
+  def testAddMultipleThreadsNodeStored(self):
+    memory = circular_replay_buffer.OutOfGraphReplayBuffer(
+        observation_shape=OBSERVATION_SHAPE,
+        stack_size=1,
+        replay_capacity=5,
+        batch_size=BATCH_SIZE,
+        use_contiguous_trajectories=True)
+    self.assertEqual(memory.cursor(), 0)
+    self.assertEqual(len(memory._trajectory), 0)
+    zeros = np.zeros(OBSERVATION_SHAPE)
+    # Add transition in main thread.
+    memory.add(zeros, 0, 0, 0)
+    # Add a terminal transition in separate thread.
+    with test_utils.mock_thread('other-thread'):
+      memory.add(zeros, 0, 0, 0)
     # Add terminal transition in main thread.
     memory.add(zeros, 0, 0, 1)
     # Check that terminal transition is added along with initial transition.
-    self.assertEqual(memory.add_count, 3)
+    self.assertEqual(memory.add_count, 2)
 
 
 class WrappedReplayBufferTest(tf.test.TestCase):

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -694,7 +694,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(memory.add_count, 0)
     self.assertEqual(len(memory._trajectories), 1)
-    self.assertEqual(memory._trajectory_lengths[0], 1)
+    self.assertEqual(memory._trajectory_lengths.values()[0], 1)
 
   def testAddTerminalNodeToTrajectoryBuffer(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(

--- a/tests/dopamine/replay_memory/circular_replay_buffer_test.py
+++ b/tests/dopamine/replay_memory/circular_replay_buffer_test.py
@@ -689,13 +689,12 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         batch_size=BATCH_SIZE,
         max_trajectory_buffer=None)
     self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     memory.add(zeros, 0, 0, 0)
     self.assertEqual(memory.cursor(), 0)
     self.assertEqual(memory.add_count, 0)
-    self.assertEqual(len(memory._trajectories), 1)
-    self.assertEqual(memory._trajectory_lengths.values()[0], 1)
+    self.assertEqual(len(memory._trajectory), 1)
 
   def testAddTerminalNodeToTrajectoryBuffer(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
@@ -705,13 +704,12 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         batch_size=BATCH_SIZE,
         max_trajectory_buffer=None)
     self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     memory.add(zeros, 0, 0, 1)
     self.assertEqual(memory.cursor(), STACK_SIZE)
     self.assertEqual(memory.add_count, STACK_SIZE)
-    self.assertEqual(len(memory._trajectories), 0)
-    self.assertEqual(len(memory._trajectory_lengths), 0)
+    self.assertEqual(len(memory._trajectory), 0)
 
   def testTrajectoryBufferSize(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
@@ -721,15 +719,14 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         batch_size=BATCH_SIZE,
         max_trajectory_buffer=11)
     self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     for _ in range(11):
       memory.add(zeros, 0, 0, 0)
     expected_length = STACK_SIZE + 10
     self.assertEqual(memory.cursor(), expected_length)
     self.assertEqual(memory.add_count, expected_length)
-    self.assertEqual(len(memory._trajectories), 0)
-    self.assertEqual(len(memory._trajectory_lengths), 0)
+    self.assertEqual(len(memory._trajectory), 0)
 
   def testAddMultipleThreads(self):
     memory = circular_replay_buffer.OutOfGraphReplayBuffer(
@@ -739,7 +736,7 @@ class OutOfGraphReplayBufferTest(tf.test.TestCase):
         batch_size=BATCH_SIZE,
         max_trajectory_buffer=None)
     self.assertEqual(memory.cursor(), 0)
-    self.assertEqual(len(memory._trajectories), 0)
+    self.assertEqual(len(memory._trajectory), 0)
     zeros = np.zeros(OBSERVATION_SHAPE)
     # Add transition in main thread.
     memory.add(zeros, 0, 0, 0)


### PR DESCRIPTION
This allows to support multiple thread writing access without having transitions of multiple occurrence overlap.