### PR TITLE
Decouple training from experience generation.

### DIFF
--- a/dopamine/agents/dqn/dqn_agent.py
+++ b/dopamine/agents/dqn/dqn_agent.py
@@ -342,7 +342,7 @@ class DQNAgent(object):
     self._record_observation(observation)
 
     if not self.eval_mode and training:
-      self._train_step()
+      self.train_step()
 
     self.action = self._select_action()
     return self.action
@@ -367,7 +367,7 @@ class DQNAgent(object):
     if not self.eval_mode:
       self._store_transition(self._last_observation, self.action, reward, False)
       if training:
-        self._train_step()
+        self.train_step()
 
     self.action = self._select_action()
     return self.action
@@ -408,7 +408,7 @@ class DQNAgent(object):
       # Choose the action with highest Q-value at the current state.
       return self._sess.run(self._q_argmax, {self.state_ph: self.state})
 
-  def _train_step(self):
+  def train_step(self):
     """Runs a single training step.
 
     Runs a training op if both:

--- a/dopamine/discrete_domains/README.md
+++ b/dopamine/discrete_domains/README.md
@@ -1,0 +1,26 @@
+# Asynchronous train runner.
+
+## Overview.
+
+The asynchronous train runner allows to train and evaluate a RL agent with an interface similar to the simple runner. On top that, the asynchronous trainer allows to:
+- run experience gathering for training in multiple threads simultaneously and asynchronously
+- decouple training from experience gathering so they occur simultaneously instead of sequentially.
+
+This is particularly useful for slow environment where a `step` takes time to return a result compared to the time necessary to run a training step.
+One use-case for such a trainer is to handle environments based on a RESTful API, where the `step` computation is performed by a remote server.
+
+## Implementation details.
+
+### Synchronization between training steps and experience gathering.
+
+Even in an asynchronous setting, it is important that training steps and experience gathering remain simultaneous, with the same speed for experience gathering and training. This ensures that:
+results are independent from different hardware set-up
+training occurs through experience generation homogeneously, in the same way as for simple training.
+
+This is achieved by adding training steps to run as experience generation goes. A training step will only be run if an additional experience step has completed.
+At the same time, experience generations will be blocked if training is delayed.
+
+### Local variables.
+
+To handle experience generation in multiple threads simultaneously, the runner will manage variables local to each thread (including an environment object per thread).
+These variables are specific to each thread id.

--- a/dopamine/discrete_domains/README.md
+++ b/dopamine/discrete_domains/README.md
@@ -2,25 +2,29 @@
 
 ## Overview.
 
-The asynchronous train runner allows to train and evaluate a RL agent with an interface similar to the simple runner. On top that, the asynchronous trainer allows to:
+With the asynchronous trainer a user can train and evaluate a RL agent with an interface similar to the simple trainer. On top that, the asynchronous trainer allows to:
 - run experience gathering for training in multiple threads simultaneously and asynchronously
 - decouple training from experience gathering so they occur simultaneously instead of sequentially.
 
-This is particularly useful for slow environment where a `step` takes time to return a result compared to the time necessary to run a training step.
+This is particularly useful for slow environment where a `step` takes much more time to return a result than the time necessary to run a training step.
 One use-case for such a trainer is to handle environments based on a RESTful API, where the `step` computation is performed by a remote server.
 
 ## Implementation details.
 
 ### Synchronization between training steps and experience gathering.
 
-Even in an asynchronous setting, it is important that training steps and experience gathering remain simultaneous, with the same speed for experience gathering and training. This ensures that:
-results are independent from different hardware set-up
-training occurs through experience generation homogeneously, in the same way as for simple training.
+Even in an asynchronous setting, it is important that training steps and experience gathering remain simultaneous, with the same speed (same speed in average with some flexibility for small variations to maintain uniformity) for experience gathering and training.
+This ensures that:
+- results are independent from different hardware set-up
+- training occurs through experience generation uniformly, in the same way as for simple training.
 
-This is achieved by adding training steps to run as experience generation goes. A training step will only be run if an additional experience step has completed.
-At the same time, experience generations will be blocked if training is delayed.
+An example of undesired behavior is if experience gathering runs 2x faster than training. In that case, once experience gathering completes there are still half the training steps to complete. The last generated samples will have been computed using a policy half way through training, and the second half of the training steps will not be used to generate any new sample. This means there is no feedback loop for the second half of training.
+
+Simultaneous training is achieved by adding training step tasks to a queue as experience generation goes. A training task is enqueued at each experience generation step, and dequeued in the thread running training steps. Therefore a training step will only be run if an additional experience step has completed (if there is a training step task to dequeue).
+This queue has a size limit for the number of training tasks cached, which ensures experience generations is blocked if training is delayed (and the queue is full).
+The size limit of the queue is set to the number of experience generation thread to handle the case where all thread complete at the same time, without blocking.
 
 ### Local variables.
 
-To handle experience generation in multiple threads simultaneously, the runner will manage variables local to each thread (including an environment object per thread).
+To handle experience generation in multiple threads simultaneously, the runner manages variables local to each thread (including an environment object per thread).
 These variables are specific to each thread id.

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -632,12 +632,12 @@ class AsyncRunner(Runner):
       thread.join()
 
   def _begin_episode(self, observation):
-    # Increments training steps and blocks is training is too slow.
+    # Increments training steps and blocks if training is too slow.
     self._training_step()
     return self._agent.begin_episode(observation, training=False)
 
   def _step(self, reward, observation):
-    # Increments training steps and blocks is training is too slow.
+    # Increments training steps and blocks if training is too slow.
     self._training_step()
     return self._agent.step(reward, observation, training=False)
 

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -634,15 +634,15 @@ class AsyncRunner(Runner):
 
   def _begin_episode(self, observation):
     # Increments training steps and blocks if training is too slow.
-    self._training_step()
+    self._enqueue_training_step()
     return self._agent.begin_episode(observation, training=False)
 
   def _step(self, reward, observation):
     # Increments training steps and blocks if training is too slow.
-    self._training_step()
+    self._enqueue_training_step()
     return self._agent.step(reward, observation, training=False)
 
-  def _training_step(self):
+  def _enqueue_training_step(self):
     """Increments training steps to run and blocks if training is too slow."""
     # If training is delayed, this will block episode generation until training
     # catches up. This ensures that training orccurs simultaneously to episode

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -640,10 +640,12 @@ class AsyncRunner(Runner):
     return self._agent.step(reward, observation, training=False)
 
   def _enqueue_training_step(self):
-    """Increments training steps to run and blocks if training is too slow."""
-    # If training is delayed, this will block episode generation until training
-    # catches up. This ensures that training orccurs simultaneously to episode
-    # generation with a constant training step / episode steps ratio.
+    """Increments training steps to run and blocks if training is too slow.
+
+    If training is delayed, this will block episode generation until training
+    catches up. This ensures that training orccurs simultaneously to episode
+    generation with a constant training step / episode steps ratio.
+    """
     if self._agent.eval_mode:
       return
     self._training_queue.put(0)  # Value doesn't matter.

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -657,7 +657,7 @@ class AsyncRunner(Runner):
       if item is None:
         self._remaining_training_steps.task_done()
         return
-      self._agent._train_step()
+      self._agent.train_step()
       self._remaining_training_steps.task_done()
 
   def _run_one_iteration(self, iteration):

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -614,13 +614,13 @@ class AsyncRunner(Runner):
     # go inline to this method.
     training_worker = threading.Thread(target=self._run_training_steps)
     training_worker.start()
-    threads = [training_worker]
+    experience_threads = []
     for iteration in range(self._start_iteration, self._num_iterations):
       self._running_iterations.put(1)
       thread = threading.Thread(
           target=self._run_one_iteration, args=(iteration,))
       thread.start()
-      threads.append(thread)
+      experience_threads.append(thread)
 
     # Wait for all tasks to complete.
     self._running_iterations.join()
@@ -628,8 +628,9 @@ class AsyncRunner(Runner):
     # Indicate training step thread to stop.
     self._remaining_training_steps.put(None)
     # Wait for all running threads to complete.
-    for thread in threads:
+    for thread in experience_threads:
       thread.join()
+    training_worker.join()
 
   def _begin_episode(self, observation):
     # Increments training steps and blocks if training is too slow.

--- a/dopamine/discrete_domains/run_experiment.py
+++ b/dopamine/discrete_domains/run_experiment.py
@@ -609,8 +609,9 @@ class AsyncRunner(Runner):
     time an iteration completes a new one starts until the right number of
     iterations is run.
     """
-    # TODO(aarg): Change the thread management to an implementation with queues.
-    # With the revamp, training might go inline to this method.
+    # TODO(aarg): Change the thread management to an implementation with queues
+    # and with a fix number of thread workers. With the revamp, training might
+    # go inline to this method.
     training_worker = threading.Thread(target=self._run_training_steps)
     training_worker.start()
     threads = []


### PR DESCRIPTION
Also replaces semaphore with queues.

This should slightly increase speed by running training steps in parallel, rather than sequentially at each environment step.

Next step is to assign a fix number of experience generation threads instead of starting a new thread at each iteration.